### PR TITLE
refac: 자재 목업 데이터의 uuid 하드 코팅

### DIFF
--- a/src/main/java/org/ever/_4ever_be_scm/config/ProductInitializer.java
+++ b/src/main/java/org/ever/_4ever_be_scm/config/ProductInitializer.java
@@ -31,37 +31,37 @@ public class ProductInitializer implements CommandLineRunner {
     private final ProductRepository productRepository;
 
     private static final List<ProductSeed> PRODUCT_SEEDS = List.of(
-        new ProductSeed("019a3df1-7843-7590-a5fd-94aa9aae7d0a", "Aluminum Panel Sheet (2.5mm)", "MATERIAL", "KG",
+        new ProductSeed("019a3df1-7843-7590-a5fd-94aa9aae7d0a", "dd406122-cbda-45c3-be70-0911a48d3efd", "Aluminum Panel Sheet (2.5mm)", "MATERIAL", "KG",
             new BigDecimal("75000"), new BigDecimal("95000")),
-        new ProductSeed("019a52d5-2824-7c7e-9826-e5c56987d189", "High-Strength Steel Coil", "MATERIAL", "KG",
+        new ProductSeed("019a52d5-2824-7c7e-9826-e5c56987d189", "8c29c196-3bbc-4d78-8a8a-0e752726121b", "High-Strength Steel Coil", "MATERIAL", "KG",
             new BigDecimal("82000"), new BigDecimal("102000")),
-        new ProductSeed("019a59a5-f5d5-7003-98b0-f8d77df4f031", "Galvanized Steel Panel", "MATERIAL", "KG",
+        new ProductSeed("019a59a5-f5d5-7003-98b0-f8d77df4f031", "1aab1ddf-c532-4010-92d9-61f3f2f212d2", "Galvanized Steel Panel", "MATERIAL", "KG",
             new BigDecimal("68000"), new BigDecimal("85000")),
-        new ProductSeed("019a52d5-1ad8-754d-af67-e541f85473c4", "Stainless Mesh Sheet", "MATERIAL", "M2",
+        new ProductSeed("019a52d5-1ad8-754d-af67-e541f85473c4", "971789f2-da29-4716-814f-913272abd9b1", "Stainless Mesh Sheet", "MATERIAL", "M2",
             new BigDecimal("54000"), new BigDecimal("69000")),
-        new ProductSeed("019a52d5-0df8-724b-a16f-7a9d3bcd5384", "ABS Resin Pellet", "MATERIAL", "KG",
+        new ProductSeed("019a52d5-0df8-724b-a16f-7a9d3bcd5384", "ca3b872b-e950-4685-89a6-b99fd465505a", "ABS Resin Pellet", "MATERIAL", "KG",
             new BigDecimal("28000"), new BigDecimal("36000")),
-        new ProductSeed("019a52d5-01a5-758a-8d36-e2ef00d8ffb7", "Polypropylene Pellet", "MATERIAL", "KG",
+        new ProductSeed("019a52d5-01a5-758a-8d36-e2ef00d8ffb7", "5b72ab09-bd63-4788-9b21-11ca574c5090", "Polypropylene Pellet", "MATERIAL", "KG",
             new BigDecimal("22000"), new BigDecimal("29000")),
-        new ProductSeed("019a52d4-f64f-7028-8715-365ab52e4879", "Carbon Fiber Fabric", "MATERIAL", "M2",
+        new ProductSeed("019a52d4-f64f-7028-8715-365ab52e4879", "bb6ab0f4-6d68-459a-825b-347b12cb0945", "Carbon Fiber Fabric", "MATERIAL", "M2",
             new BigDecimal("110000"), new BigDecimal("140000")),
-        new ProductSeed("019a52d4-e876-709e-8646-d31b8db20a95", "Glass Fiber Mat", "MATERIAL", "KG",
+        new ProductSeed("019a52d4-e876-709e-8646-d31b8db20a95", "a3b1c740-8bf9-4141-a113-f30bdc1dd488", "Glass Fiber Mat", "MATERIAL", "KG",
             new BigDecimal("36000"), new BigDecimal("47000")),
-        new ProductSeed("019a52d4-dc52-7605-868b-0ed7486cb106", "Tempered Glass Insert", "MATERIAL", "EA",
+        new ProductSeed("019a52d4-dc52-7605-868b-0ed7486cb106", "e538f74c-669c-46d4-b70d-909442afbd08", "Tempered Glass Insert", "MATERIAL", "EA",
             new BigDecimal("120000"), new BigDecimal("150000")),
-        new ProductSeed("019a52d4-cffd-7876-9a7e-34590cc2c447", "Polycarbonate Lens", "MATERIAL", "KG",
+        new ProductSeed("019a52d4-cffd-7876-9a7e-34590cc2c447", "0b39d2a7-370c-44d1-aefa-b38e8de31625", "Polycarbonate Lens", "MATERIAL", "KG",
             new BigDecimal("45000"), new BigDecimal("58000")),
-        new ProductSeed("019a52d4-c49d-77d8-912d-960432b4565c", "Rubber Seal Strip", "MATERIAL", "M",
+        new ProductSeed("019a52d4-c49d-77d8-912d-960432b4565c", "5d911685-2230-472b-b30e-051502e245e6", "Rubber Seal Strip", "MATERIAL", "M",
             new BigDecimal("15000"), new BigDecimal("22000")),
-        new ProductSeed("019a52d4-b8d1-7509-9072-31d2e147055e", "NVH Damping Laminate", "MATERIAL", "M2",
+        new ProductSeed("019a52d4-b8d1-7509-9072-31d2e147055e", "70f5ad3c-d600-4400-9b72-25e6bc85dc33", "NVH Damping Laminate", "MATERIAL", "M2",
             new BigDecimal("26000"), new BigDecimal("34000")),
-        new ProductSeed("019a52d4-ab46-7abe-9071-025222fb6144", "Chrome Trim Strip", "MATERIAL", "M",
+        new ProductSeed("019a52d4-ab46-7abe-9071-025222fb6144", "77baedf8-3810-46f5-aa7e-82f596dee60e", "Chrome Trim Strip", "MATERIAL", "M",
             new BigDecimal("33000"), new BigDecimal("43000")),
-        new ProductSeed("019a52d4-96be-72cb-85dd-19fbe3d80880", "Hardware Fastening Kit", "MATERIAL", "SET",
+        new ProductSeed("019a52d4-96be-72cb-85dd-19fbe3d80880", "db5b6809-db60-4b60-b0d9-a51df9317c3b", "Hardware Fastening Kit", "MATERIAL", "SET",
             new BigDecimal("32000"), new BigDecimal("42000")),
-        new ProductSeed("019a52d4-8961-76f0-a2a8-0dbd756d30da", "Surface Coating Pack", "MATERIAL", "L",
+        new ProductSeed("019a52d4-8961-76f0-a2a8-0dbd756d30da", "8900c53f-8040-460a-8f75-14bf53866cb3", "Surface Coating Pack", "MATERIAL", "L",
             new BigDecimal("30000"), new BigDecimal("39000")),
-        new ProductSeed("019a52d4-7141-7a42-8674-a4c6597acfd7", "Structural Adhesive Pack", "MATERIAL", "KG",
+        new ProductSeed("019a52d4-7141-7a42-8674-a4c6597acfd7", "c9f41fc0-5c18-4d30-b155-2941239641c1", "Structural Adhesive Pack", "MATERIAL", "KG",
             new BigDecimal("29000"), new BigDecimal("38000"))
     );
 
@@ -101,6 +101,7 @@ public class ProductInitializer implements CommandLineRunner {
             }
 
             Product product = Product.builder()
+                .id(seed.productId())
                 .category(seed.category())
                 .supplierCompany(company)
                 .productName(seed.productName())
@@ -120,6 +121,7 @@ public class ProductInitializer implements CommandLineRunner {
 
     private record ProductSeed(
         String supplierCompanyId,
+        String productId,
         String productName,
         String category,
         String unit,


### PR DESCRIPTION
## 요약
- `ProductSeed`에 `productId` 필드 추가
- 기존 목업 데이터에 고유 `productId` 값 반영
- `Product` 빌더 로직 수정하여 `productId` 초기화 처리

## 관련 이슈
- Closes #46 